### PR TITLE
Remove c9 references

### DIFF
--- a/_includes/practice-problems-1.md
+++ b/_includes/practice-problems-1.md
@@ -46,7 +46,7 @@ Programming Summary][intro-to-programming-summary].
 
 ## Setup for Downloads
 
-**We recommend you use [repl.it][https://repl.it] to do the downloaded practice
+**We recommend you use [repl.it][repl] to do the downloaded practice
 problems.** See our [setup instructions](../setup) for instructions
 on how to use repl.it.
 
@@ -94,3 +94,4 @@ on how to use repl.it.
 [caesar_cipher_sol]: https://repl.it/@AppAcademy/CaesarCipher
 [num_repeats]: https://repl.it/@AppAcademy/PP1-numrepeats
 [num_repeats_sol]: https://repl.it/@AppAcademy/PP1-numrepeats-Solution
+[repl]: https://repl.it

--- a/_includes/practice-problems-1.md
+++ b/_includes/practice-problems-1.md
@@ -46,9 +46,9 @@ Programming Summary][intro-to-programming-summary].
 
 ## Setup for Downloads
 
-**We strongly recommend you use Cloud9 (c9.io) to do the downloaded practice
+**We recommend you use [repl.it][https://repl.it] to do the downloaded practice
 problems.** See our [setup instructions](../setup) for instructions
-on how to use Cloud9.
+on how to use repl.it.
 
 [intro-to-programming-summary]: ../introduction-to-programming-summary
 [download-problems]: ../practice-problems-1.zip

--- a/_includes/practice-problems-1.md
+++ b/_includes/practice-problems-1.md
@@ -46,9 +46,7 @@ Programming Summary][intro-to-programming-summary].
 
 ## Setup for Downloads
 
-**We recommend you use [repl.it][repl] to do the downloaded practice
-problems.** See our [setup instructions](../setup) for instructions
-on how to use repl.it.
+**We recommend you use [repl.it][repl] to do the practice problems.** See our [setup instructions](../setup) for instructions on how to set up your own machine to run these practice problems.
 
 [intro-to-programming-summary]: ../introduction-to-programming-summary
 [download-problems]: ../practice-problems-1.zip

--- a/_includes/practice-problems-2.md
+++ b/_includes/practice-problems-2.md
@@ -15,13 +15,7 @@
 
 [Download][download-problems]
 
-If you choose to download the files, be sure to follow [these instructions][setup] to setup a
-web based ruby development environment. Once installed you will be able to run
-all of the practice problems from there.
-
-Alternatively, you might prefer to setup Ruby on your own computer. If
-you choose to do so, you can download the whole prep-work repository,
-including the practice problems, in [ZIP format][repo-zip].
+If you choose to download the files, be sure to follow [the advanced instructions][setup] to setup your own computer. You can then download the whole prep-work repository, including the practice problems, in [ZIP format][repo-zip].
 
 [download-problems]: ../practice-problems-2.zip
 [repo-zip]: https://github.com/appacademy/prep-work/archive/master.zip
@@ -48,9 +42,7 @@ including the practice problems, in [ZIP format][repo-zip].
 ## Downloaded Practice Problem Instructions
 
 First, open a terminal at the
-`prep-work/coding-test-2/practice-problems` directory. If you are using
-Cloud9, the easiest way to do this is to right-click on that directory
-in the file tree and select "Open Terminal Here".
+`prep-work/coding-test-2/practice-problems` directory.
 
 Next, we'll need to install the dependencies. We'll use a gem called
 `bundler` to do this. Once we install bundler, we can use it to install
@@ -69,10 +61,7 @@ you are supposed to do.
 
 You will write your code in the corresponding files in `lib` (e.g.,
 `lib/00_nearest_larger.rb`). I've filled them out with a blank method
-for you. You'll need to write the code to make the specs pass. In
-Cloud9, you'll probably want to keep one text editor panel open to write
-your code, and a terminal panel open to run the specs and read the
-specs' output.
+for you. You'll need to write the code to make the specs pass.
 
 Work through the problems one by one; when you complete writing the
 code, run the spec to check your work. Make sure to look at the

--- a/_includes/quality/practice-problems-1.md
+++ b/_includes/quality/practice-problems-1.md
@@ -49,12 +49,6 @@ Once you feel you have a good grasp of the practice problems, please move onto
 
 [technical-interview-prep-2]: ../../technical-interview-2
 
-## Setup for Downloads
-
-**We strongly recommend you use Cloud9 (c9.io) to do the downloaded practice
-problems.** See our [setup instructions](../setup) for instructions
-on how to use Cloud9.
-
 [intro-to-programming-summary]: ../introduction-to-programming-summary
 [download-problems]: ../practice-problems-1.zip
 [reverse]: https://repl.it/Br5n/0

--- a/_includes/quality/practice-problems-2.md
+++ b/_includes/quality/practice-problems-2.md
@@ -15,43 +15,41 @@
 
 [Download][download-problems]
 
-If you choose to download the files, be sure to follow [these instructions][setup] to setup a
-web based ruby development environment. Once installed you will be able to run
-all of the practice problems from there.
-
-Alternatively, you might prefer to setup Ruby on your own computer. If
-you choose to do so, you can download the whole prep-work repository,
-including the practice problems, in [ZIP format][repo-zip].
+If you choose to download the files, be sure to follow [the advanced instructions][setup] to setup your own computer. You can then download the whole prep-work repository, including the practice problems, in [ZIP format][repo-zip].
 
 [download-problems]: ../practice-problems-2.zip
 [repo-zip]: https://github.com/appacademy/prep-work/archive/master.zip
-[setup]: ../../technical-interview-1/setup
-[nearest_larger]: https://repl.it/BrI2/0
-[nearest_larger_sol]: https://repl.it/BrIg/0
-[no_repeats]: https://repl.it/BrI5/0
-[no_repeats_sol]: https://repl.it/BrIh/0
-[letter_count]: https://repl.it/BrI6/0
-[letter_count_sol]: https://repl.it/BrIi/0
-[ordered_vowel_words]: https://repl.it/BrI7/0
-[ordered_vowel_words_sol]: https://repl.it/BrIj/0
-[wonky_coins]: https://repl.it/BrI9/0
-[wonky_coins_sol]: https://repl.it/BrIm/0
-[morse_encode]: https://repl.it/BrIa/0
-[morse_encode_sol]: https://repl.it/BrIn/0
-[word_unscrambler]: https://repl.it/BrIb/0
+[setup]: ../../coding-test-1/setup
+[nearest_larger]: https://repl.it/@AppAcademy/NearestLarger
+[nearest_larger_sol]: https://repl.it/@AppAcademy/NearestLargerSolution
+[no_repeats]: https://repl.it/@AppAcademy/NoRepeats
+[no_repeats_sol]: https://repl.it/@AppAcademy/NoRepeatsSolution
+[letter_count]: https://repl.it/@AppAcademy/LetterCount
+[letter_count_sol]: https://repl.it/@AppAcademy/LetterCountSolution
+[ordered_vowel_words]: https://repl.it/@AppAcademy/OrderedVowelWords
+[ordered_vowel_words_sol]: https://repl.it/@AppAcademy/OrderedVowelsSolution
+[wonky_coins]: https://repl.it/@AppAcademy/WonkyCoins
+[wonky_coins_sol]: https://repl.it/@AppAcademy/WonkyCoinsSolution
+[morse_encode]: https://repl.it/@AppAcademy/MorseEncode
+[morse_encode_sol]: https://repl.it/@AppAcademy/MorseEncodeSolution
+[word_unscrambler]: https://repl.it/@AppAcademy/WordUnscrambler
 [word_unscrambler_sol]: https://repl.it/BrIp/0
-[rec_intersection]: https://repl.it/BrIc/0
-[rec_intersection_sol]: https://repl.it/BrIr/0
-[bubble_sort]: https://repl.it/BrId/0
-[bubble_sort_sol]: https://repl.it/BrIu/0
+[rec_intersection]: https://repl.it/@AppAcademy/RectangleIntersection
+[rec_intersection_sol]: https://repl.it/@AppAcademy/RectangleIntersectionSolution
+[bubble_sort]: https://repl.it/@AppAcademy/BubbleSort
+[bubble_sort_sol]: https://repl.it/@AppAcademy/BubbleSortSolution
 
 ## Downloaded Practice Problem Instructions
 
 First, open a terminal at the
- `prep-work/coding-test-2/practice-problems` directory. If you are using
-Cloud9, the easiest way to do this is to right-click on that directory
-in the file tree and select "Open Terminal Here". Run `bundle install`.
-This will install the Ruby libraries needed to run the specs.
+`prep-work/coding-test-2/practice-problems` directory.
+
+Next, we'll need to install the dependencies. We'll use a gem called
+`bundler` to do this. Once we install bundler, we can use it to install
+all the other Ruby gems we need to run the specs.
+
+    gem install bundler
+    bundle install
 
 You can then run the specs for an individual problem like so:
 
@@ -63,10 +61,7 @@ you are supposed to do.
 
 You will write your code in the corresponding files in `lib` (e.g.,
 `lib/00_nearest_larger.rb`). I've filled them out with a blank method
-for you. You'll need to write the code to make the specs pass. In
-Cloud9, you'll probably want to keep one text editor panel open to write
-your code, and a terminal panel open to run the specs and read the
-specs' output.
+for you. You'll need to write the code to make the specs pass.
 
 Work through the problems one by one; when you complete writing the
 code, run the spec to check your work. Make sure to look at the

--- a/_includes/quality/practice-problems-2.md
+++ b/_includes/quality/practice-problems-2.md
@@ -19,25 +19,25 @@ If you choose to download the files, be sure to follow [the advanced instruction
 
 [download-problems]: ../practice-problems-2.zip
 [repo-zip]: https://github.com/appacademy/prep-work/archive/master.zip
-[setup]: ../../coding-test-1/setup
-[nearest_larger]: https://repl.it/@AppAcademy/NearestLarger
-[nearest_larger_sol]: https://repl.it/@AppAcademy/NearestLargerSolution
-[no_repeats]: https://repl.it/@AppAcademy/NoRepeats
-[no_repeats_sol]: https://repl.it/@AppAcademy/NoRepeatsSolution
-[letter_count]: https://repl.it/@AppAcademy/LetterCount
-[letter_count_sol]: https://repl.it/@AppAcademy/LetterCountSolution
-[ordered_vowel_words]: https://repl.it/@AppAcademy/OrderedVowelWords
-[ordered_vowel_words_sol]: https://repl.it/@AppAcademy/OrderedVowelsSolution
-[wonky_coins]: https://repl.it/@AppAcademy/WonkyCoins
-[wonky_coins_sol]: https://repl.it/@AppAcademy/WonkyCoinsSolution
-[morse_encode]: https://repl.it/@AppAcademy/MorseEncode
-[morse_encode_sol]: https://repl.it/@AppAcademy/MorseEncodeSolution
-[word_unscrambler]: https://repl.it/@AppAcademy/WordUnscrambler
+[setup]: ../../technical-interview-1/setup
+[nearest_larger]: https://repl.it/BrI2/0
+[nearest_larger_sol]: https://repl.it/BrIg/0
+[no_repeats]: https://repl.it/BrI5/0
+[no_repeats_sol]: https://repl.it/BrIh/0
+[letter_count]: https://repl.it/BrI6/0
+[letter_count_sol]: https://repl.it/BrIi/0
+[ordered_vowel_words]: https://repl.it/BrI7/0
+[ordered_vowel_words_sol]: https://repl.it/BrIj/0
+[wonky_coins]: https://repl.it/BrI9/0
+[wonky_coins_sol]: https://repl.it/BrIm/0
+[morse_encode]: https://repl.it/BrIa/0
+[morse_encode_sol]: https://repl.it/BrIn/0
+[word_unscrambler]: https://repl.it/BrIb/0
 [word_unscrambler_sol]: https://repl.it/BrIp/0
-[rec_intersection]: https://repl.it/@AppAcademy/RectangleIntersection
-[rec_intersection_sol]: https://repl.it/@AppAcademy/RectangleIntersectionSolution
-[bubble_sort]: https://repl.it/@AppAcademy/BubbleSort
-[bubble_sort_sol]: https://repl.it/@AppAcademy/BubbleSortSolution
+[rec_intersection]: https://repl.it/BrIc/0
+[rec_intersection_sol]: https://repl.it/BrIr/0
+[bubble_sort]: https://repl.it/BrId/0
+[bubble_sort_sol]: https://repl.it/BrIu/0
 
 ## Downloaded Practice Problem Instructions
 

--- a/_includes/quality/setup.md
+++ b/_includes/quality/setup.md
@@ -2,11 +2,11 @@
 
 It is not required to install Ruby on your own machine before the
 coding challenge. The easiest way to start using Ruby is to use
-**[repl.it][https://repl.it]**; it is free.
+**[repl.it](https://repl.it)**; it is free.
 
 Here are the key steps:
 
-0. Go to [repl.it][https://repl.it]
+0. Go to [repl.it](https://repl.it)
 0. Select Ruby as your programming language
 0. You can choose to sign up for a repl.it account or code anonymously
 

--- a/_includes/quality/setup.md
+++ b/_includes/quality/setup.md
@@ -1,38 +1,16 @@
-## Cloud9 (c9.io)
+## REPL.it
 
 It is not required to install Ruby on your own machine before the
-technical interview. The easiest way to start using Ruby is to use
-**[Cloud9][c9.io]**; it is free.
+coding challenge. The easiest way to start using Ruby is to use
+**[repl.it][https://repl.it]**; it is free.
 
 Here are the key steps:
 
-0. Go to [c9.io][c9.io] and sign up.
-0. After you've signed up and confirmed your email, delete the default
-   demo-project.
-0. Next, create a new project. Make sure the custom template is selected.
-0. C9.io will provide a text editor for you to edit Ruby code in the
-   browser. You can write Ruby code in the text editor. At the bottom
-   is a console, you can run your code in the console.
-0. Run the following commands in the console. This will download the zipped
-   file and unzip it for you. You should have a folder with the practice
-   problems.
-
-  ```
-   wget http://prepwork.appacademy.io/coding-test-1/practice-problems-1.zip
-
-   unzip practice-problems-1.zip
-  ```
-
-You should be able to do all the prepwork using c9.io.
-
-[c9.io]: https://www.c9.io/
+0. Go to [repl.it][https://repl.it]
+0. Select Ruby as your programming language
+0. You can choose to sign up for a repl.it account or code anonymously
 
 ## Advanced Setup
-
-You do not have to install Ruby on your own machine to do the
-prep-work. When starting out, you want to spend as much time coding
-and as little time as possible on banal setup tasks. Therefore, we
-highly recommend you use c9.io.
 
 Setting up Ruby on your machine can be a frustrating process. Setting
 up Ruby is not the same as programming; even great Rubyists can be
@@ -40,11 +18,11 @@ frustrated by the hoops they have to jump through to setup their
 machine. Don't be discouraged if it's difficult!
 
 To install Ruby on Windows, we recommend
-[RubyInstaller][ruby-installer]. To install on Mac OSX, look at
-[Tokaido][tokaido].
+[RubyInstaller][ruby-installer]. To install on Mac OSX, check out our
+[dotfiles][dotfiles] for more instructions.
 
 [ruby-installer]: http://rubyinstaller.org/
-[tokaido]: https://github.com/tokaido/tokaidoapp
+[dotfiles]: https://github.com/appacademy/dotfiles
 
 ### Text Editor
 

--- a/_includes/setup.md
+++ b/_includes/setup.md
@@ -2,11 +2,11 @@
 
 It is not required to install Ruby on your own machine before the
 coding challenge. The easiest way to start using Ruby is to use
-**[repl.it][https://repl.it]**; it is free.
+**[repl.it](https://repl.it)**; it is free.
 
 Here are the key steps:
 
-0. Go to [repl.it][https://repl.it]
+0. Go to [repl.it](https://repl.it)
 0. Select Ruby as your programming language
 0. You can choose to sign up for a repl.it account or code anonymously
 

--- a/_includes/setup.md
+++ b/_includes/setup.md
@@ -1,40 +1,16 @@
-## Cloud9 (c9.io)
+## REPL.it
 
 It is not required to install Ruby on your own machine before the
 coding challenge. The easiest way to start using Ruby is to use
-**[Cloud9][c9.io]**; it is free.
+**[repl.it][https://repl.it]**; it is free.
 
 Here are the key steps:
 
-0. Go to [c9.io][c9.io] and sign up.
-0. After you've signed up and confirmed your email, create a new workspace.
-0. When creating the workspace, choose "Blank" as the template.
-0. C9.io will provide a text editor for you to edit Ruby code in the
-   browser. You can write Ruby code in the text editor. At the bottom
-   is a console, you can run your code in the console.
-0. Run the following commands in the console. This will download the zipped
-   file and unzip it for you. You should have a folder with the practice
-   problems.
-
-```
-  wget http://prepwork.appacademy.io/coding-test-1/practice-problems-1.zip
-
-  unzip practice-problems-1.zip
-```
-
-Here's a brief screencast that demonstrates the steps above:
-https://www.dropbox.com/s/hpl0qiolvimfzph/c9%20set%20up.mov?dl=0
-
-You should be able to do all the prepwork using c9.io.
-
-[c9.io]: https://www.c9.io/
+0. Go to [repl.it][https://repl.it]
+0. Select Ruby as your programming language
+0. You can choose to sign up for a repl.it account or code anonymously
 
 ## Advanced Setup
-
-You do not have to install Ruby on your own machine to do the
-prep-work. When starting out, you want to spend as much time coding
-and as little time as possible on banal setup tasks. Therefore, we
-highly recommend you use c9.io.
 
 Setting up Ruby on your machine can be a frustrating process. Setting
 up Ruby is not the same as programming; even great Rubyists can be


### PR DESCRIPTION
Cloud9 is now Amazon Cloud9. We now recommend that students use repl.it for pre-acceptance work.